### PR TITLE
Fix: Added H2 database dependency and local config to fix startup crash

### DIFF
--- a/src/login-service/pom.xml
+++ b/src/login-service/pom.xml
@@ -31,6 +31,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>


### PR DESCRIPTION
---


## 📌 Description

The login-service was failing to start locally because it was missing a database configuration. I added the H2 runtime dependency and a default application.properties to allow the service to run out-of-the-box

---

## 🔗 Related Issue

Fixes local startup crash

---

## 🛠️ Type of Change

Please mark the relevant option:

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Configuration / DevOps change
- [ ] Other (please explain)

---

## 🧪 How Was This Tested?

Describe how you verified your changes:

- [ ] Docker Compose runs successfully
- [ ] Frontend loads correctly
- [x] Service builds without errors
- [ ] Documentation renders correctly
- [x] Manual testing

---

## 📸 Screenshots (if applicable)


<img width="1245" height="785" alt="b40cae38-4d2e-4f09-8d62-9930f9355ad6" src="https://github.com/user-attachments/assets/e23aca37-6b1e-4084-8f76-39e23f338dec" />


## ✅ Checklist

Please confirm the following:

- [x] My code follows the project structure
- [x] I tested my changes locally
- [x] I linked the relevant issue
- [x] I kept this PR focused and minimal
- [x] I am open to feedback and changes

