### PR TITLE
[Enhancement] Add Initialization and Teardown Scripts for Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,39 @@ MicroForge/
 │   ├── notification-service/# Node.js service
 │   └── docker-compose.yml   # Local development setup
 ├── manifests/kubernetes/    # K8s deployment manifests
+├── scripts/                 # Automation scripts
+│   ├── init.sh             # Terraform initialization script
+│   ├── teardown.sh         # Terraform cleanup script
+│   └── k8s-setup.sh        # Kubernetes setup script
 └── README.md                # Project documentation
 ```
+
+---
+
+## 📜 **Terraform Automation Scripts**
+
+The project includes convenient scripts for Terraform infrastructure management:
+
+### **Initialization Script** (`scripts/init.sh`)
+Automates the complete Terraform setup process:
+```bash
+./scripts/init.sh
+```
+**What it does:**
+- Initializes Terraform with `terraform init -input=false`
+- Validates configuration with `terraform validate`
+- Formats code recursively with `terraform fmt -recursive`
+
+### **Teardown Script** (`scripts/teardown.sh`)
+Cleans up all Terraform-managed resources:
+```bash
+./scripts/teardown.sh
+```
+**What it does:**
+- Destroys all Terraform-managed infrastructure with `terraform destroy --auto-approve`
+- Automatically confirms destruction (non-interactive mode)
+
+> **Note**: Both scripts use `set -e` for error handling, meaning they will exit immediately if any command fails.
 
 ### **Environment Setup**
 ```bash

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "Initializing Terraform..."
+terraform init -input=false
+
+echo "Validating configuration..."
+terraform validate
+
+echo "Formatting code..."
+terraform fmt -recursive
+
+echo "Initialization complete."

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+echo "Destroying Terraform-managed resources..."
+terraform destroy --auto-approve
+
+echo "Teardown complete."


### PR DESCRIPTION
## Summary
This PR adds automation scripts for Terraform infrastructure management as requested in issue #21.

## Changes Made
-  Created `scripts/init.sh` - Automated Terraform initialization script
-  Created `scripts/teardown.sh` - Automated resource cleanup script
-  Made both scripts executable (`chmod +x`)
-  Updated README.md with usage instructions

## Script Details

### `scripts/init.sh`
- Initializes Terraform with `terraform init -input=false`
- Validates configuration with `terraform validate`
- Formats code recursively with `terraform fmt -recursive`
- Uses `set -e` for error handling (exits on any error)

### `scripts/teardown.sh`
- Destroys all Terraform-managed resources with `terraform destroy --auto-approve`
- Uses `set -e` for error handling

## Usage
```bash
# Initialize Terraform
./scripts/init.sh

# Clean up resources
./scripts/teardown.sh
```

## Testing
Both scripts follow the exact specifications from the issue:
- `init.sh` initializes, validates, and formats
-  `teardown.sh` destroys all resources
-  Both have executable permissions
-  Both use `set -e` for error handling
-  README updated with usage instructions

Closes #21